### PR TITLE
Onion block fixes

### DIFF
--- a/src/main/java/net/orcinus/overweightfarming/common/blocks/AlliumBushBlock.java
+++ b/src/main/java/net/orcinus/overweightfarming/common/blocks/AlliumBushBlock.java
@@ -1,0 +1,44 @@
+package net.orcinus.overweightfarming.common.blocks;
+
+import net.minecraft.block.*;
+import net.minecraft.registry.tag.FluidTags;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.WorldView;
+import net.orcinus.overweightfarming.common.registry.OFObjects;
+
+import java.util.Iterator;
+
+public class AlliumBushBlock extends TallFlowerBlock {
+
+    public AlliumBushBlock(Settings settings) {
+        super(settings);
+    }
+
+
+    @Override
+    public boolean canPlaceAt(BlockState state, WorldView world, BlockPos pos) {
+
+        if (!super.canPlaceAt(state, world, pos) ) {
+            Iterator<Direction> var4 = Direction.Type.HORIZONTAL.iterator();
+            Direction direction;
+            BlockState blockState;
+            do {
+                if (!var4.hasNext()) {
+                    BlockState blockState2 = world.getBlockState(pos.down());
+                    return (blockState2.isOf(OFObjects.OVERWEIGHT_ONION) && !world.getBlockState(pos.up()).isLiquid());
+                }
+                direction = var4.next();
+                blockState = world.getBlockState(pos.offset(direction));
+            } while (!blockState.isSolid() && !world.getFluidState(pos.offset(direction)).isIn(FluidTags.LAVA));
+
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+}

--- a/src/main/java/net/orcinus/overweightfarming/common/blocks/OverweightOnionBlock.java
+++ b/src/main/java/net/orcinus/overweightfarming/common/blocks/OverweightOnionBlock.java
@@ -35,22 +35,4 @@ public class OverweightOnionBlock extends CropFullBlock {
             world.setBlockState(below, Blocks.HANGING_ROOTS.getDefaultState(), 2);
         }
     }
-
-
-    @Override
-    public boolean canPlaceAt(BlockState state, WorldView world, BlockPos pos) {
-        Iterator<Direction> var4 = Direction.Type.HORIZONTAL.iterator();
-        Direction direction;
-        BlockState blockState;
-        do {
-            if (!var4.hasNext()) {
-                BlockState blockState2 = world.getBlockState(pos.down());
-                return (blockState2.isOf(OFObjects.ALLIUM_BUSH) && !world.getBlockState(pos.up()).isLiquid());
-            }
-            direction = var4.next();
-            blockState = world.getBlockState(pos.offset(direction));
-        } while (!blockState.isSolid() && !world.getFluidState(pos.offset(direction)).isIn(FluidTags.LAVA));
-
-        return false;
-    }
 }

--- a/src/main/java/net/orcinus/overweightfarming/common/registry/OFObjects.java
+++ b/src/main/java/net/orcinus/overweightfarming/common/registry/OFObjects.java
@@ -62,7 +62,7 @@ public interface OFObjects {
     Block OVERWEIGHT_GINGER = register("overweight_ginger_block", new CropFullBlock(OVERWEIGHT_GINGER_STEM, FabricBlockSettings.create().strength(1.0F).sounds(BlockSoundGroup.CROP)), true, gen());
     Block PEELED_OVERWEIGHT_GINGER = register("peeled_overweight_ginger_block", new Block(FabricBlockSettings.copy(OVERWEIGHT_GINGER)), true, gen());
    //BLOCKS
-    Block ALLIUM_BUSH = register("allium_bush", new TallFlowerBlock(FabricBlockSettings.create().pistonBehavior(PistonBehavior.DESTROY).strength(1).noCollision().breakInstantly().sounds(BlockSoundGroup.GRASS)), true, new Item.Settings());
+    Block ALLIUM_BUSH = register("allium_bush", new AlliumBushBlock(FabricBlockSettings.create().pistonBehavior(PistonBehavior.DESTROY).strength(1).noCollision().breakInstantly().sounds(BlockSoundGroup.GRASS)), true, new Item.Settings());
     Block OVERWEIGHT_ONION = register("overweight_onion_block", new OverweightOnionBlock(ALLIUM_BUSH, FabricBlockSettings.create().pistonBehavior(PistonBehavior.DESTROY).strength(1).strength(1.0F).sounds(BlockSoundGroup.CROP)), true, gen());
     Block PEELED_OVERWEIGHT_ONION = register("peeled_overweight_onion_block", new Block(FabricBlockSettings.copy(OVERWEIGHT_ONION)), true, gen());
     Block OVERWEIGHT_COCOA = register("overweight_cocoa_block", new OverweightCocoaBlock(null, FabricBlockSettings.create().pistonBehavior(PistonBehavior.DESTROY).strength(1).sounds(BlockSoundGroup.CROP).breakInstantly()), true, gen());


### PR DESCRIPTION
As it is (at least for Fabric 1.20, I haven't tested or confirmed this on other versions), players are only allowed to place Overweight Onion blocks on top of an Allium Bush block.

Additionally, since the Allium Bush block is a standard `TallFlowerBlock`, it is not allowed to be placed on top of an Overweight Onion block. When an Overweight Onion is grown, the bush breaks off immediately.

Basically all I did was create an `AlliumBushBlock` class, and moved the block placement restrictions from the `OverweightOnionBlock`,  and modified to work for the Allium Bush