### PR TITLE
fix stems attached to overweight crops not surviving neighboring block updates

### DIFF
--- a/src/main/java/net/orcinus/overweightfarming/blocks/CropFullBlock.java
+++ b/src/main/java/net/orcinus/overweightfarming/blocks/CropFullBlock.java
@@ -33,6 +33,12 @@ public class CropFullBlock extends BushBlock implements BonemealableBlock {
         return SHAPE;
     }
 
+    @Override
+    public VoxelShape getBlockSupportShape(BlockState state, BlockGetter level, BlockPos pos) {
+        //fixes the issue where CropStemBlocks attached to CropFullBlocks cannot survive neighboring block updates
+        return getShape(state, level, pos, CollisionContext.empty());
+    }
+
     public Block getStemBlock() {
         return this.stemBlock;
     }


### PR DESCRIPTION
fixes #80 

The issue arose because CropFullBlocks have **empty collision shapes** (due to setting the noCollision flag to true), causing the **CropStemBlock#canSurvive** check to always fail because **BlockState#isFaceSturdy** uses **Block#getBlockSupportShape** which returns the empty collision shape by default.
